### PR TITLE
Using declarations for proper Disposal and CompressionLevel > 0

### DIFF
--- a/src/RDAExplorer/RDAReader.cs
+++ b/src/RDAExplorer/RDAReader.cs
@@ -224,9 +224,8 @@ namespace RDAExplorer
 
         private void ReadDirEntries(byte[] buffer, BlockInfo block, RDAMemoryResidentHelper mrm)
         {
-            MemoryStream memoryStream = new MemoryStream(buffer);
-            BinaryReader reader = new BinaryReader(memoryStream);
-
+            using MemoryStream memoryStream = new MemoryStream(buffer);
+            using BinaryReader reader = new BinaryReader(memoryStream);
             for (uint fileId = 0; fileId < block.fileCount; ++fileId)
             {
                 byte[] fileNameBytes = reader.ReadBytes((int)DirEntry.GetFilenameSize());

--- a/src/RDAExplorer/RDAWriter.cs
+++ b/src/RDAExplorer/RDAWriter.cs
@@ -19,12 +19,12 @@ namespace RDAExplorer
 
         public void Write(string Filename, FileHeader.Version version, bool compress, RDAReader originalReader, BackgroundWorker wrk)
         {
-            FileStream fileStream = new FileStream(Filename, FileMode.Create);
-            BinaryWriter writer = new BinaryWriter(fileStream);
+            using FileStream fileStream = new FileStream(Filename, FileMode.Create);
+            using BinaryWriter writer = new BinaryWriter(fileStream);
 
             // we'll write the header at the end, when we know the offset to the first block
             writer.BaseStream.Position = FileHeader.GetSize(version);
-            
+
             // blocks are organized by file type. there is one RDAFolder per block
             List<RDAFolder> blockFolders = RDABlockCreator.GenerateOf(Folder);
             int numBlocks = (int)originalReader.NumSkippedBlocks + blockFolders.Count;
@@ -50,7 +50,7 @@ namespace RDAExplorer
                 // anyway (we won't fit our "own" data in perfectly). And I'm just too afraid to get the
                 // bin-packing wrong.
                 writer.BaseStream.WriteBytes((skippedBlock.offset - (ulong)writer.BaseStream.Position), 0);
-                
+
                 // write the data
                 originalReader.CopySkippedDataSextion(skippedBlock.offset, skippedBlock.size, writer.BaseStream);
 
@@ -100,7 +100,8 @@ namespace RDAExplorer
                 for (int dirEntryIndex = 0; dirEntryIndex < blockFolder.Files.Count; ++dirEntryIndex)
                 {
                     RDAFile file = blockFolder.Files[dirEntryIndex];
-                    DirEntry dirEntry = new DirEntry() {
+                    DirEntry dirEntry = new DirEntry()
+                    {
                         compressed = dirEntryCompressedSizes[file],
                         filesize = file.UncompressedSize,
                         filename = file.FileName,
@@ -145,8 +146,6 @@ namespace RDAExplorer
             FileHeader fileHeader = FileHeader.Create(version);
             fileHeader.firstBlockOffset = blockInfoOffsets[0];
             WriteHeader(writer, 0, fileHeader, version);
-
-            fileStream.Close();
         }
 
         private static void WriteHeader(BinaryWriter writer, ulong offset, FileHeader fileHeader, FileHeader.Version version)

--- a/src/RDAExplorer/ZLib/ZLib.cs
+++ b/src/RDAExplorer/ZLib/ZLib.cs
@@ -17,6 +17,8 @@ namespace RDAExplorer.ZLib
 -       private static extern int compress(byte[] des, ref int destLen, byte[] src, int srcLen);
         */
 
+        private const int COMPRESSION_LEVEL = 2;
+
         public static byte[] Uncompress(byte[] input, int uncompressedSize)
         {
             //byte[] des = new byte[uncompressedSize];
@@ -49,7 +51,7 @@ namespace RDAExplorer.ZLib
         {
             using var stream = new MemoryStream(input);
             using var memoryStream = new MemoryStream();
-            using var deflaterStream = new DeflaterOutputStream(memoryStream, new Deflater(0));
+            using var deflaterStream = new DeflaterOutputStream(memoryStream, new Deflater(COMPRESSION_LEVEL));
 
 
             stream.Position = 0;


### PR DESCRIPTION
This PR uses the using declarations introduced in C#8.0 to create Streams and BinaryReaders with integrated calls to Dispose() at the end of the scope they are created in. Utilizing using declarations instead of using statements results in less clutter and at least one less extra nested scope.

This PR also increases the compression level of the ZLib Class to 2 because a compression level of 0 results in uncompressed output, effectively rendering the compression feature moot.